### PR TITLE
set html webpack plugin as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
   "precommit": "yarn test",
   "dependencies": {
     "fs": "^0.0.1-security",
-    "html-webpack-plugin": "^4.0.0-beta.11",
     "lodash": "^4.17.15",
     "path": "^0.12.7"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^4.0.0-beta.11"
+    "html-webpack-plugin": ">=4.0.0-beta.11"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",


### PR DESCRIPTION
html webpack should be a peer dependency of this library

see similar libraries:
https://github.com/GoogleChromeLabs/preload-webpack-plugin/blob/master/package.json
https://github.com/swimmadude66/html-webpack-link-type-plugin/blob/develop/package.json

It should prevent the problem of two instances of html webpack plugin being installed

I think I encountered this related issue:
https://github.com/jantimon/html-webpack-plugin/issues/1091