### PR TITLE
Update example link to Netlify URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ ga('send', 'pageview');
 ```
 
 ### Other Examples
-See a few other working examples here: https://github.com/colbyfayock/html-webpack-partials-plugin/tree/master/examples
+See a few other working examples here: https://html-webpack-partials-plugin.netlify.app/
+
+See the source for the examples here: https://github.com/colbyfayock/html-webpack-partials-plugin/tree/master/examples
 
 ## Notes
 


### PR DESCRIPTION
Hey @colbyfayock, 
After I submitted this PR I noticed your netlify samples site, 
https://html-webpack-partials-plugin.netlify.app/variables/dist/

I now see why you had the encoding as you did..

Would it be possible to update the readme link in the repo to point to the netlify URL, rather than the [repo link](https://github.com/colbyfayock/html-webpack-partials-plugin/blame/master/README.md#L210)

When I was reviewing it, I noticed the encoding and was confused what I was actually supposed to put in the webpack.config file. 

Thanks for your time! 