### PR TITLE
chore: added apply method type to HtmlWebpackPartialsPlugin class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
-import { Plugin } from 'webpack';
+import { Compiler, Plugin } from 'webpack';
 
 declare class HtmlWebpackPartialsPlugin extends Plugin {
     constructor(settings: HtmlWebpackPartialsPlugin.Settings | HtmlWebpackPartialsPlugin.Settings[]);
+    apply(compiler: Compiler): void;
 }
 
 declare namespace HtmlWebpackPartialsPlugin {


### PR DESCRIPTION
Fix type error below.
```
Type 'HtmlWebpackPartialsPlugin' is not assignable to type '((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance'.
Property 'apply' is missing in type 'HtmlWebpackPartialsPlugin' but required in type 'WebpackPluginInstance'.ts(2322)
```